### PR TITLE
Balancing Random Stats

### DIFF
--- a/Randomiser/Meta.ini
+++ b/Randomiser/Meta.ini
@@ -483,8 +483,8 @@ Title=Max. HP
 Type=Number
 Integer=1
 Min=0
-Default=15
-Tooltip=HP controls how much damage a vehicle can take without blowing up. [Default: 15]
+Default=10
+Tooltip=HP controls how much damage a vehicle can take without blowing up. [Default: 10]
 Page=Variables
 Group=Random Stat Variables
 


### PR DESCRIPTION
## Summary of changes
<!--- Replace the space with an `x` in all the boxes that apply: -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality) (target dev!)
- [ ] My change adds a new setting/requires a change to the README & meta.ini
- [x] I have updated the README & meta.ini accordingly

## Description of changes
Balances the Vehicle HP, down from 15 to 10, this allows for a more enjoyable experience when in levels that have a lot of destruction vehicles e.g Cell-Outs, Hellfish
## Any additional information
